### PR TITLE
pnpm-context: handle Windows project paths

### DIFF
--- a/bin/pnpm-context.mjs
+++ b/bin/pnpm-context.mjs
@@ -147,7 +147,7 @@ async function getMetafilesFromPnpmSelector (selector, cwd, options = {}) {
  */
 async function getPackagePathsFromPnpmSelector (selector, cwd) {
   const projects = await readProjects(cwd, [parsePackageSelector(selector, cwd)])
-  return Object.keys(projects.selectedProjectsGraph).map(p => relative(cwd, p))
+  return Object.keys(projects.selectedProjectsGraph).map(p => relative(cwd, p).replaceAll('\\', '/'))
 }
 
 /**


### PR DESCRIPTION
While testing this script on Windows, I discovered that globby does not find anything if you give it a folder path that uses the `\` separator. Apparently it uses fast-glob, which [requires you to normalise the paths yourself](https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows).

This change should resolve that issue.